### PR TITLE
Make pcov coverage work

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,8 @@ RUN apk add -u --no-cache \
 	php7-xml \
 	php7-exif \
 	php7-simplexml \
+	php7-tokenizer \
+	php7-xmlwriter \
 	mysql \
 	mysql-client \
 	imagemagick \

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,4 +1,8 @@
 #!/bin/sh
 mysqld_safe --datadir=/var/lib/mysql &>/dev/null &
 sleep 1
+
+# Run https://github.com/krakjoe/pcov-clobber if installed.
+if [ -f /code/vendor/bin/pcov ]; then /code/vendor/bin/pcov clobber; fi
+
 /code/vendor/bin/phpunit "$@"


### PR DESCRIPTION
Adds necessary extensions to make pcov work for coverage. (n.b. xmlwriter may not be technically required, think it depends on what format you output as)

Requires installing https://github.com/krakjoe/pcov-clobber via require-ext, but will run it for you automatically.