### PR TITLE
Wait up to 5s for mysql, checking every second

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,9 +1,11 @@
 #!/bin/sh
 mysqld_safe --datadir=/var/lib/mysql &>/dev/null &
 
-# Wait up to 5 seconds for mysql to start, checking once a second.
 retries=5
-until [ "$(pgrep mysql | wc -l)" <> 0 ] || [ $retries -le 0 ]; do
+status=1
+until [ $status -eq 0 ] || [ $retries -le 0 ]; do
+    mysql -uroot 2>/dev/null
+    status=$?
     retries=$((retries-1))
     sleep 1
 done

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,6 +1,12 @@
 #!/bin/sh
 mysqld_safe --datadir=/var/lib/mysql &>/dev/null &
-sleep 1
+
+# Wait up to 5 seconds for mysql to start, checking once a second.
+retries=5
+until [ "$(pgrep mysql | wc -l)" <> 0 ] || [ $retries -le 0 ]; do
+    retries=$((retries-1))
+    sleep 1
+done
 
 # Run https://github.com/krakjoe/pcov-clobber if installed.
 if [ -f /code/vendor/bin/pcov ]; then /code/vendor/bin/pcov clobber; fi


### PR DESCRIPTION
If MySQL takes >1s to start, which happens with some regularity in CI, the tests will not execute and a database connection error will be displayed in the test logs.

Instead of "sleep 1," retry every second for 5s or until mysql starts.

This logic could probably improved, but this consistently allows the tests to run once mysql is available on my local, where before it would only succeed ~60% of the time.

See #10 