### PR TITLE
Update Dockerfile to use WP 6.8 as default

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine:3.13
 
-ARG WP_VERSION=5.4
+ARG WP_VERSION=6.8
 
 RUN apk add -u --no-cache \
 	composer \


### PR DESCRIPTION
5.4 is quite old, this bumps the version to 6.8